### PR TITLE
ADD support for person in invoice creating, FIX error when code in po…

### DIFF
--- a/src/FakturowniaInvoice.php
+++ b/src/FakturowniaInvoice.php
@@ -56,6 +56,8 @@ class FakturowniaInvoice extends FakturowniaDataObject
             'phone' => ""
         );
         $this->buyer = array(
+            'first_name' => "",
+            'last_name' => "",
             'name' => "",
             'tax_number' => null,
             'street' => "",
@@ -150,6 +152,10 @@ class FakturowniaInvoice extends FakturowniaDataObject
         );
 
         $invoice->isBuyerCompany = ($json['buyer_company'] > 0 ? true : false);
+        if(!$invoice->isBuyerCompany) {
+            $invoice->buyer['first_name'] = $json['buyer_first_name'];
+            $invoice->buyer['last_name'] = $json['buyer_last_name'];
+        }
 
         if (isset($json['recipient_name']) && !empty($json['recipient_name'])) {
             $invoice->recipient = array(
@@ -202,6 +208,8 @@ class FakturowniaInvoice extends FakturowniaDataObject
             'seller_country' => $this->seller['country'],
             'seller_phone' => $this->seller['phone'],
             'buyer_name' => $this->buyer['name'],
+            'buyer_first_name' => $this->buyer['first_name'],
+            'buyer_last_name' => $this->buyer['last_name'],
             'buyer_tax_no' => $this->buyer['tax_number'],
             'buyer_street' => $this->buyer['street'],
             'buyer_post_code' => $this->buyer['post_code'],

--- a/src/FakturowniaPosition.php
+++ b/src/FakturowniaPosition.php
@@ -46,9 +46,12 @@ class FakturowniaPosition extends FakturowniaDataObject
     {
         $position = new FakturowniaPosition($json['name'], $json['quantity'], $json['total_price_gross'], false, $json['tax']);
         $position->id = $json['id'];
-        $position->code = $json['code'];
-        $position->description = $json['description'];
 
+        if (isset($json['code']) && !empty($json['code'])) {
+            $position->code = $json['code'];
+        }
+
+        $position->description = $json['description'];
         $position->quantityUnit = $json['quantity_unit'];
 
         // ----------[ DATA PROCESSING END ]----------


### PR DESCRIPTION
When setting isBuyerCompany as 1 and creating invoice as in docs then we have:
`"{"code":"error","message":{"client":"Błędy zapisu: ","buyer_last_name":["- nie może być puste"],"positions":[{},{}]}}"`
So we need to add this parameters (first_name and last_name) to available list.

Additionaly, when I was debugging I couldn't make createFromJson because I had error about no 'code' in positions. 
This is not required and to make it works I had to turn this on in configuration in fakturownia: Show product code (wyświetlaj kod produktu). So now fixed.